### PR TITLE
Add \[...\] and \(...\) delimiters to KaTeX auto-render config

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -40,8 +40,10 @@
         renderMathInElement( document.body, {
           delimiters: [
             {left: "$$", right: "$$", display: true},
+            {left: "\\[", right: "\\]", display: true},
             {left: "[%", right: "%]", display: true},
-            {left: "$", right: "$", display: false}
+            {left: "$", right: "$", display: false},
+            {left: "\\(", right: "\\)", display: false}
           ]}
         );
       });

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -48,6 +48,11 @@ code, pre, .highlighter-rouge, .highlight, .codecell {
   font-family: "ComicCodeLigatures-Bold", monospace !important;
 }
 
+:not(pre) > code {
+  background-color: transparent;
+  border: none;
+}
+
 // ==========================================
 // Cobalt syntax highlighting theme
 // ==========================================


### PR DESCRIPTION
kramdown converts $$...$$ to \[...\] and $...$ to \(...\) during
markdown processing, but the KaTeX auto-render script was only
configured to look for $$, [%..%], and $ delimiters. This caused
math expressions to appear as raw LaTeX on the rendered page.

https://claude.ai/code/session_012uFfC6PPJu7tY4bTXGn68J