### PR TITLE
Refine code font styling for inline and block contexts

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -250,15 +250,12 @@ li { margin-bottom: 0.25rem; }
   font-display: swap;
 }
 
-code, pre, .highlight, .codecell {
-  font-family: "Atkinson Hyperlegible Mono", monospace;
-}
-
 pre, .highlight, .codecell, .astro-code {
   font-family: "ComicCodeLigatures-Bold", "Atkinson Hyperlegible Mono", monospace;
 }
 
 :not(pre) > code {
+  font-family: "Atkinson Hyperlegible Mono", monospace;
   background: color.adjust($bg, $lightness: 8%);
   padding: 0.15em 0.35em;
   border-radius: 3px;


### PR DESCRIPTION
## Summary
Reorganized font-family declarations for code elements to apply different typefaces based on context—using ComicCodeLigatures for code blocks and Atkinson Hyperlegible Mono for inline code.

## Key Changes
- Removed the combined selector `code, pre, .highlight, .codecell` that applied ComicCodeLigatures to all code elements
- Kept the block-level code styling (`pre, .highlight, .codecell, .astro-code`) with ComicCodeLigatures font
- Applied Atkinson Hyperlegible Mono specifically to inline code (`:not(pre) > code`) for better readability in body text

## Implementation Details
This change ensures that inline code snippets within paragraphs use a more readable monospace font, while code blocks continue to use the stylized ComicCodeLigatures font for visual distinction.

https://claude.ai/code/session_01AxB7qpA3zaTGzTyk7M4ANJ