### PR TITLE
Add font-family: inherit to code inside code blocks

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -278,6 +278,7 @@ pre, .highlight, .codecell, .astro-code {
   code {
     background: transparent;
     padding: 0;
+    font-family: inherit;
   }
 }
 
@@ -305,6 +306,7 @@ pre, .highlight, .codecell, .astro-code {
     background: transparent;
     color: $code-text;
     padding: 0;
+    font-family: inherit;
   }
 
   // -- Token colors (cobalt2) --


### PR DESCRIPTION
The browser UA stylesheet sets `code { font-family: monospace }` which overrides font inheritance from the parent pre/highlight. Adding explicit `font-family: inherit` on `.astro-code code` and `.highlight code` ensures block code elements pick up Comic Code from their parent.

https://claude.ai/code/session_01AxB7qpA3zaTGzTyk7M4ANJ