### PR TITLE
Add redirect pages for blog URL structure migration

### DIFF
--- a/public/2020/09/06/example-post.html
+++ b/public/2020/09/06/example-post.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/blog/2020-09-06-example-post/">
+  <link rel="canonical" href="https://lucaswiman.github.io/blog/2020-09-06-example-post/">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected, <a href="/blog/2020-09-06-example-post/">click here</a>.</p>
+</body>
+</html>

--- a/public/2020/09/23/how-to-retrieve-a-file-in-git-by-its-object-hash.html
+++ b/public/2020/09/23/how-to-retrieve-a-file-in-git-by-its-object-hash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/blog/2020-09-23-how-to-retrieve-a-file-in-git-by-its-object-hash/">
+  <link rel="canonical" href="https://lucaswiman.github.io/blog/2020-09-23-how-to-retrieve-a-file-in-git-by-its-object-hash/">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected, <a href="/blog/2020-09-23-how-to-retrieve-a-file-in-git-by-its-object-hash/">click here</a>.</p>
+</body>
+</html>

--- a/public/2022/04/26/Beta-Distribution-and-Unfair-Coins.html
+++ b/public/2022/04/26/Beta-Distribution-and-Unfair-Coins.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/blog/2022-04-26-beta-distribution-and-unfair-coins/">
+  <link rel="canonical" href="https://lucaswiman.github.io/blog/2022-04-26-beta-distribution-and-unfair-coins/">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected, <a href="/blog/2022-04-26-beta-distribution-and-unfair-coins/">click here</a>.</p>
+</body>
+</html>

--- a/public/2022/04/27/Derivation-of-the-Poisson-Distribution.html
+++ b/public/2022/04/27/Derivation-of-the-Poisson-Distribution.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/blog/2022-04-27--derivation-of-the-poisson-distribution/">
+  <link rel="canonical" href="https://lucaswiman.github.io/blog/2022-04-27--derivation-of-the-poisson-distribution/">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected, <a href="/blog/2022-04-27--derivation-of-the-poisson-distribution/">click here</a>.</p>
+</body>
+</html>

--- a/public/2022/05/24/Heterdox-Dr-Seuss-Readings.html
+++ b/public/2022/05/24/Heterdox-Dr-Seuss-Readings.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/blog/2022-05-24-heterdox-dr-seuss-readings/">
+  <link rel="canonical" href="https://lucaswiman.github.io/blog/2022-05-24-heterdox-dr-seuss-readings/">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected, <a href="/blog/2022-05-24-heterdox-dr-seuss-readings/">click here</a>.</p>
+</body>
+</html>

--- a/public/2023/06/04/macos-sandbox.html
+++ b/public/2023/06/04/macos-sandbox.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/blog/2023-06-04--macos-sandbox/">
+  <link rel="canonical" href="https://lucaswiman.github.io/blog/2023-06-04--macos-sandbox/">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected, <a href="/blog/2023-06-04--macos-sandbox/">click here</a>.</p>
+</body>
+</html>

--- a/public/2025/01/05/teaching-transformers-arithmetic.html
+++ b/public/2025/01/05/teaching-transformers-arithmetic.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/blog/2025-01-05-teaching-transformers-arithmetic/">
+  <link rel="canonical" href="https://lucaswiman.github.io/blog/2025-01-05-teaching-transformers-arithmetic/">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected, <a href="/blog/2025-01-05-teaching-transformers-arithmetic/">click here</a>.</p>
+</body>
+</html>

--- a/public/prolog/testing/unit-tests/prosaic-prolog/2015/12/05/swi-prolog-unit-tests.html
+++ b/public/prolog/testing/unit-tests/prosaic-prolog/2015/12/05/swi-prolog-unit-tests.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/blog/2015-12-05-swi-prolog-unit-tests/">
+  <link rel="canonical" href="https://lucaswiman.github.io/blog/2015-12-05-swi-prolog-unit-tests/">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected, <a href="/blog/2015-12-05-swi-prolog-unit-tests/">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds HTTP redirect pages to maintain backward compatibility after migrating the blog URL structure from date-based paths (e.g., `/2020/09/06/example-post.html`) to a new slug-based format under `/blog/` (e.g., `/blog/2020-09-06-example-post/`).

## Changes
- Added 8 redirect HTML pages that use meta refresh and canonical links to forward users from old URLs to new blog post locations
- Redirects cover blog posts from 2015, 2020, 2022, 2023, and 2025
- Each redirect page includes:
  - HTTP meta refresh for automatic redirection
  - Canonical link tag for SEO purposes
  - Fallback manual redirect link for users with JavaScript disabled

## Implementation Details
- Redirect pages use `meta http-equiv="refresh"` with `content="0"` for immediate redirection
- Canonical links point to the new blog URL structure to consolidate SEO value
- All redirects maintain the original post content at the new location while preserving old URL accessibility

https://claude.ai/code/session_01CHRMtsRgAwuMosz3zEUEVu